### PR TITLE
Implement canvas card battle prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.vite/
+.DS_Store
+npm-debug.log*
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mmbcp2",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc && cp src/index.html dist/index.html"
+  }
+}

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1,0 +1,320 @@
+import { gain } from './guts';
+import {
+  Attribute,
+  Card,
+  CardRequirement,
+  CardEffectContext,
+  Monster,
+  PlayerState,
+  Tribe,
+} from './types';
+import { applyMonsterDamage, damagePlayer, healMonster } from './rules';
+
+interface CardTemplate {
+  id: string;
+  name: string;
+  description: string;
+  attribute: Attribute;
+  requirement: CardRequirement;
+  target: Card['target'];
+  effect: Card['effect'];
+}
+
+interface MonsterTemplate {
+  id: string;
+  name: string;
+  attribute: Attribute;
+  tribe: Tribe;
+  maxHp: number;
+  attack: number;
+  defense: number;
+}
+
+let cardSequence = 0;
+let monsterSequence = 0;
+
+function cloneRequirement(requirement: CardRequirement): CardRequirement {
+  return {
+    cost: requirement.cost
+      ? {
+          guts: requirement.cost.guts,
+          attributes: requirement.cost.attributes ? { ...requirement.cost.attributes } : undefined,
+        }
+      : undefined,
+    requiresAttribute: requirement.requiresAttribute,
+    requiresTribe: requirement.requiresTribe,
+    requiresMonsterId: requirement.requiresMonsterId,
+  };
+}
+
+function instantiateCard(template: CardTemplate): Card {
+  cardSequence += 1;
+  return {
+    id: template.id,
+    instanceId: `${template.id}-${cardSequence}`,
+    name: template.name,
+    description: template.description,
+    attribute: template.attribute,
+    requirement: cloneRequirement(template.requirement),
+    target: template.target,
+    effect: template.effect,
+  };
+}
+
+function instantiateMonster(template: MonsterTemplate): Monster {
+  monsterSequence += 1;
+  return {
+    id: template.id,
+    instanceId: `${template.id}-${monsterSequence}`,
+    name: template.name,
+    attribute: template.attribute,
+    tribe: template.tribe,
+    maxHp: template.maxHp,
+    hp: template.maxHp,
+    attack: template.attack,
+    defense: template.defense,
+  };
+}
+
+function isMonster(entity: Monster | PlayerState): entity is Monster {
+  return 'maxHp' in entity;
+}
+
+const flameBolt: CardTemplate = {
+  id: 'flame-bolt',
+  name: 'フレイムボルト',
+  description: '火属性の仲間が必要。敵モンスターに4ダメージ。',
+  attribute: 'fire',
+  requirement: {
+    cost: { guts: 1, attributes: { fire: 1 } },
+    requiresAttribute: 'fire',
+  },
+  target: 'enemy-monster',
+  effect: ({ state, sourcePlayer, targets, log }) => {
+    const target = targets.find(isMonster);
+    if (!target) {
+      log('対象が選択されていません。');
+      return;
+    }
+    applyMonsterDamage(state, target, 4, `${sourcePlayer.name}のフレイムボルト`);
+  },
+};
+
+const packHowl: CardTemplate = {
+  id: 'pack-howl',
+  name: '群れの遠吠え',
+  description: '獣人・獣が必要。敵モンスターに3ダメージ。',
+  attribute: 'wind',
+  requirement: {
+    cost: { guts: 1 },
+    requiresTribe: 'beast',
+  },
+  target: 'enemy-monster',
+  effect: ({ state, sourcePlayer, targets, log }) => {
+    const target = targets.find(isMonster);
+    if (!target) {
+      log('攻撃対象がいません。');
+      return;
+    }
+    applyMonsterDamage(state, target, 3, `${sourcePlayer.name}の群れの遠吠え`);
+  },
+};
+
+const luminaPrayer: CardTemplate = {
+  id: 'lumina-prayer',
+  name: 'ルミナの祈り',
+  description: 'ルミナ賢者専用。味方モンスターを4回復。',
+  attribute: 'light',
+  requirement: {
+    cost: { guts: 2, attributes: { light: 1 } },
+    requiresMonsterId: 'lumina-sage',
+  },
+  target: 'ally-monster',
+  effect: ({ state, sourcePlayer, targets, log }) => {
+    const target = targets.find(isMonster);
+    if (!target) {
+      log('回復対象がいません。');
+      return;
+    }
+    healMonster(state, target, 4, `${sourcePlayer.name}の祈り`);
+  },
+};
+
+const gutsCharge: CardTemplate = {
+  id: 'guts-charge',
+  name: 'ガッツチャージ',
+  description: 'ガッツ+2、無属性エネルギー+1を得る。',
+  attribute: 'neutral',
+  requirement: {},
+  target: 'none',
+  effect: ({ sourcePlayer, log }) => {
+    gain(sourcePlayer.guts, { guts: 2, attributes: { neutral: 1 } });
+    log(`${sourcePlayer.name}はガッツ2と無属性エネルギー1を得た。`);
+  },
+};
+
+const guardianShield: CardTemplate = {
+  id: 'guardian-shield',
+  name: '守護者の盾',
+  description: '味方モンスターの防御を高め、2回復する。',
+  attribute: 'light',
+  requirement: {
+    cost: { guts: 1 },
+  },
+  target: 'ally-monster',
+  effect: ({ state, sourcePlayer, targets, log }) => {
+    const target = targets.find(isMonster);
+    if (!target) {
+      log('守る対象がいません。');
+      return;
+    }
+    target.defense += 1;
+    healMonster(state, target, 2, `${sourcePlayer.name}の守護者の盾`);
+    log(`${target.name}の防御が1上昇した。`);
+  },
+};
+
+const stoneHurl: CardTemplate = {
+  id: 'stone-hurl',
+  name: 'ストーンハール',
+  description: '土属性の仲間が必要。敵モンスターに3ダメージ。',
+  attribute: 'earth',
+  requirement: {
+    cost: { guts: 1, attributes: { earth: 1 } },
+    requiresAttribute: 'earth',
+  },
+  target: 'enemy-monster',
+  effect: ({ state, sourcePlayer, targets, log }) => {
+    const target = targets.find(isMonster);
+    if (!target) {
+      log('攻撃対象がいません。');
+      return;
+    }
+    applyMonsterDamage(state, target, 3, `${sourcePlayer.name}のストーンハール`);
+  },
+};
+
+const shadowCurse: CardTemplate = {
+  id: 'shadow-curse',
+  name: 'シャドウカース',
+  description: '闇属性の仲間が必要。敵プレイヤーに2ダメージ。',
+  attribute: 'dark',
+  requirement: {
+    cost: { guts: 2, attributes: { dark: 1 } },
+    requiresAttribute: 'dark',
+  },
+  target: 'enemy-player',
+  effect: ({ state, sourcePlayer, targets, log }) => {
+    const target = targets.find((entity): entity is PlayerState => !isMonster(entity));
+    if (!target) {
+      log('ターゲットがいません。');
+      return;
+    }
+    damagePlayer(state, target, 2, `${sourcePlayer.name}のシャドウカース`);
+  },
+};
+
+const darkRecovery: CardTemplate = {
+  id: 'dark-recovery',
+  name: 'ダークリカバリー',
+  description: '味方モンスター1体を3回復する。',
+  attribute: 'dark',
+  requirement: {
+    cost: { guts: 1 },
+  },
+  target: 'ally-monster',
+  effect: ({ state, sourcePlayer, targets, log }) => {
+    const target = targets.find(isMonster);
+    if (!target) {
+      log('回復対象がいません。');
+      return;
+    }
+    healMonster(state, target, 3, `${sourcePlayer.name}の闇の癒し`);
+  },
+};
+
+function buildDeck(entries: Array<[CardTemplate, number]>): Card[] {
+  const deck: Card[] = [];
+  for (const [template, count] of entries) {
+    for (let i = 0; i < count; i += 1) {
+      deck.push(instantiateCard(template));
+    }
+  }
+  return deck;
+}
+
+export function createStarterDeck(): Card[] {
+  return buildDeck([
+    [flameBolt, 2],
+    [packHowl, 2],
+    [luminaPrayer, 1],
+    [gutsCharge, 2],
+    [guardianShield, 1],
+  ]);
+}
+
+export function createEnemyDeck(): Card[] {
+  return buildDeck([
+    [stoneHurl, 2],
+    [shadowCurse, 2],
+    [darkRecovery, 2],
+  ]);
+}
+
+const guardianWolf: MonsterTemplate = {
+  id: 'guardian-wolf',
+  name: '守護狼ガルム',
+  attribute: 'wind',
+  tribe: 'beast',
+  maxHp: 14,
+  attack: 3,
+  defense: 1,
+};
+
+const flameMage: MonsterTemplate = {
+  id: 'flame-mage',
+  name: '炎術士ライラ',
+  attribute: 'fire',
+  tribe: 'human',
+  maxHp: 10,
+  attack: 2,
+  defense: 0,
+};
+
+const luminaSage: MonsterTemplate = {
+  id: 'lumina-sage',
+  name: '賢者ルミナ',
+  attribute: 'light',
+  tribe: 'human',
+  maxHp: 8,
+  attack: 1,
+  defense: 0,
+};
+
+const stoneGoblin: MonsterTemplate = {
+  id: 'stone-goblin',
+  name: '岩肌のゴブリン',
+  attribute: 'earth',
+  tribe: 'beast',
+  maxHp: 9,
+  attack: 3,
+  defense: 0,
+};
+
+const shadowImp: MonsterTemplate = {
+  id: 'shadow-imp',
+  name: '影のインプ',
+  attribute: 'dark',
+  tribe: 'spirit',
+  maxHp: 7,
+  attack: 2,
+  defense: 0,
+};
+
+export function createPlayerMonsters(): Monster[] {
+  return [guardianWolf, flameMage, luminaSage].map(instantiateMonster);
+}
+
+export function createEnemyMonsters(): Monster[] {
+  return [stoneGoblin, shadowImp].map(instantiateMonster);
+}

--- a/src/guts.ts
+++ b/src/guts.ts
@@ -1,0 +1,117 @@
+import { Attribute, EnergyCost, EnergyMap, GutsContext } from './types';
+
+export const ATTRIBUTE_ORDER: Attribute[] = [
+  'neutral',
+  'fire',
+  'water',
+  'earth',
+  'wind',
+  'light',
+  'dark',
+];
+
+const DEFAULT_MAX_GUTS = 10;
+const DEFAULT_PER_TURN_GAIN = 3;
+
+function createEnergyMap(initial = 0): EnergyMap {
+  return ATTRIBUTE_ORDER.reduce<EnergyMap>((map, attribute) => {
+    map[attribute] = initial;
+    return map;
+  }, {} as EnergyMap);
+}
+
+interface ContextOptions {
+  guts?: number;
+  maxGuts?: number;
+  perTurnGain?: number;
+  attributes?: Partial<Record<Attribute, number>>;
+}
+
+export function createContext(options: ContextOptions = {}): GutsContext {
+  const context: GutsContext = {
+    guts: options.guts ?? 0,
+    maxGuts: options.maxGuts ?? DEFAULT_MAX_GUTS,
+    perTurnGain: options.perTurnGain ?? DEFAULT_PER_TURN_GAIN,
+    attributes: createEnergyMap(),
+  };
+
+  if (options.attributes) {
+    for (const [key, value] of Object.entries(options.attributes)) {
+      const attribute = key as Attribute;
+      context.attributes[attribute] = value ?? context.attributes[attribute];
+    }
+  }
+
+  return context;
+}
+
+export function startTurn(context: GutsContext): GutsContext {
+  context.guts = Math.min(context.maxGuts, context.guts + context.perTurnGain);
+  return context;
+}
+
+export function gain(context: GutsContext, reward: EnergyCost): void {
+  if (reward.guts) {
+    context.guts = Math.min(context.maxGuts, context.guts + reward.guts);
+  }
+
+  if (reward.attributes) {
+    for (const [key, amount] of Object.entries(reward.attributes)) {
+      const attribute = key as Attribute;
+      const value = amount ?? 0;
+      context.attributes[attribute] = (context.attributes[attribute] ?? 0) + value;
+    }
+  }
+}
+
+export function canPay(context: GutsContext, cost?: EnergyCost): boolean {
+  if (!cost) {
+    return true;
+  }
+
+  if (cost.guts && context.guts < cost.guts) {
+    return false;
+  }
+
+  if (cost.attributes) {
+    for (const [key, amount] of Object.entries(cost.attributes)) {
+      const attribute = key as Attribute;
+      const requirement = amount ?? 0;
+      if ((context.attributes[attribute] ?? 0) < requirement) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+export function pay(context: GutsContext, cost?: EnergyCost): boolean {
+  if (!cost) {
+    return true;
+  }
+
+  if (!canPay(context, cost)) {
+    return false;
+  }
+
+  if (cost.guts) {
+    context.guts -= cost.guts;
+  }
+
+  if (cost.attributes) {
+    for (const [key, amount] of Object.entries(cost.attributes)) {
+      const attribute = key as Attribute;
+      const value = amount ?? 0;
+      context.attributes[attribute] = Math.max(0, (context.attributes[attribute] ?? 0) - value);
+    }
+  }
+
+  return true;
+}
+
+export function resetAttributes(context: GutsContext): void {
+  for (const attribute of ATTRIBUTE_ORDER) {
+    context.attributes[attribute] = 0;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>MMBCP2 Prototype</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body {
+        margin: 0;
+        background: #10131a;
+        color: #f0f3ff;
+        font-family: 'Segoe UI', sans-serif;
+        overflow: hidden;
+      }
+      canvas {
+        display: block;
+        margin: 0 auto;
+        background: #0b0d12;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,0 +1,87 @@
+import { GameState, Card, Monster, PlayerIndex, PlayerState } from './types';
+
+export interface InputCallbacks {
+  onCardSelected(card: Card): void;
+  onMonsterTarget(owner: PlayerIndex, monster: Monster): void;
+  onPlayerTarget(owner: PlayerIndex): void;
+  onBackground(): void;
+  onEndTurn(): void;
+}
+
+function pointInRect(x: number, y: number, rect: { x: number; y: number; width: number; height: number }): boolean {
+  return x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
+}
+
+function findCardByInstance(player: PlayerState, instanceId: string): Card | undefined {
+  return player.hand.find((card) => card.instanceId === instanceId);
+}
+
+function findMonsterByInstance(player: PlayerState, instanceId: string): Monster | undefined {
+  return player.monsters.find((monster) => monster.instanceId === instanceId);
+}
+
+export function installInputHandlers(
+  canvas: HTMLCanvasElement,
+  state: GameState,
+  callbacks: InputCallbacks,
+): void {
+  canvas.addEventListener('click', (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+
+    if (pointInRect(x, y, state.layout.endTurnRect)) {
+      callbacks.onEndTurn();
+      return;
+    }
+
+    for (const [instanceId, cardRect] of Object.entries(state.layout.handRects)) {
+      if (pointInRect(x, y, cardRect)) {
+        const card = findCardByInstance(state.players[0], instanceId);
+        if (card) {
+          callbacks.onCardSelected(card);
+        }
+        return;
+      }
+    }
+
+    for (const [instanceId, monsterRect] of Object.entries(state.layout.enemyMonsterRects)) {
+      if (pointInRect(x, y, monsterRect)) {
+        const monster = findMonsterByInstance(state.players[1], instanceId);
+        if (monster) {
+          callbacks.onMonsterTarget(1, monster);
+        }
+        return;
+      }
+    }
+
+    for (const [instanceId, monsterRect] of Object.entries(state.layout.playerMonsterRects)) {
+      if (pointInRect(x, y, monsterRect)) {
+        const monster = findMonsterByInstance(state.players[0], instanceId);
+        if (monster) {
+          callbacks.onMonsterTarget(0, monster);
+        }
+        return;
+      }
+    }
+
+    if (pointInRect(x, y, state.layout.enemyStatusRect)) {
+      callbacks.onPlayerTarget(1);
+      return;
+    }
+
+    if (pointInRect(x, y, state.layout.playerStatusRect)) {
+      callbacks.onPlayerTarget(0);
+      return;
+    }
+
+    callbacks.onBackground();
+  });
+
+  window.addEventListener('keydown', (event) => {
+    if (event.code === 'Space') {
+      event.preventDefault();
+      callbacks.onEndTurn();
+    }
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,243 @@
+import { createEnemyDeck, createEnemyMonsters, createPlayerMonsters, createStarterDeck } from './cards';
+import { installInputHandlers } from './input';
+import { renderGame } from './render';
+import {
+  Card,
+  GameState,
+  Monster,
+  PlayerState,
+  Rect,
+} from './types';
+import {
+  addLog,
+  canPlayCard,
+  checkVictory,
+  drawCard,
+  getValidTargets,
+  monsterAttackMonster,
+  monsterAttackPlayer,
+  pickDefaultTargets,
+  playCard,
+  shuffle,
+} from './rules';
+import { createContext, startTurn } from './guts';
+
+const canvas = document.getElementById('game') as HTMLCanvasElement;
+if (!canvas) {
+  throw new Error('ゲーム用のキャンバスが見つかりません。');
+}
+canvas.width = 1024;
+canvas.height = 720;
+
+const context = canvas.getContext('2d');
+if (!context) {
+  throw new Error('CanvasRenderingContext2D がサポートされていません。');
+}
+const renderContext: CanvasRenderingContext2D = context;
+
+const rng = () => Math.random();
+
+function createPlayer(id: 'player' | 'enemy', index: 0 | 1, name: string, deck: Card[], monsters: Monster[]): PlayerState {
+  return {
+    id,
+    index,
+    name,
+    hp: 20,
+    deck,
+    hand: [],
+    discard: [],
+    monsters,
+    guts: createContext(),
+  };
+}
+
+const playerState = createPlayer('player', 0, 'プレイヤー', createStarterDeck(), createPlayerMonsters());
+const enemyState = createPlayer('enemy', 1, 'エネミー', createEnemyDeck(), createEnemyMonsters());
+
+shuffle(playerState.deck, rng);
+shuffle(enemyState.deck, rng);
+
+function createEmptyLayout(): GameState['layout'] {
+  return {
+    handRects: {} as Record<string, Rect>,
+    playerMonsterRects: {} as Record<string, Rect>,
+    enemyMonsterRects: {} as Record<string, Rect>,
+    playerStatusRect: { x: 0, y: 0, width: 0, height: 0 },
+    enemyStatusRect: { x: 0, y: 0, width: 0, height: 0 },
+    energyRect: { x: 0, y: 0, width: 0, height: 0 },
+    endTurnRect: { x: 0, y: 0, width: 0, height: 0 },
+    logRect: { x: 0, y: 0, width: 0, height: 0 },
+  };
+}
+
+const state: GameState = {
+  players: [playerState, enemyState],
+  activePlayer: 0,
+  turn: 1,
+  phase: 'player',
+  log: [],
+  rng,
+  layout: createEmptyLayout(),
+  lastUpdate: performance.now(),
+};
+
+function resetSelection(): void {
+  state.pendingSelection = undefined;
+  state.selectedCardId = undefined;
+}
+
+function finalizeVictory(): void {
+  const winner = checkVictory(state);
+  if (winner && !state.winner) {
+    state.winner = winner;
+    state.phase = 'victory';
+    addLog(state, winner === 'player' ? 'プレイヤーの勝利！' : 'エネミーの勝利…');
+  }
+}
+
+function startPlayerTurn(): void {
+  state.phase = 'player';
+  state.activePlayer = 0;
+  resetSelection();
+  addLog(state, `--- ターン${state.turn} プレイヤー ---`);
+  startTurn(playerState.guts);
+  addLog(state, `ガッツ残量: ${playerState.guts.guts}`);
+  drawCard(state, playerState);
+}
+
+function startEnemyTurn(): void {
+  if (state.winner) {
+    return;
+  }
+  state.phase = 'enemy';
+  state.activePlayer = 1;
+  resetSelection();
+  addLog(state, `--- ターン${state.turn} エネミー ---`);
+  startTurn(enemyState.guts);
+  addLog(state, `エネミーのガッツ: ${enemyState.guts.guts}`);
+  drawCard(state, enemyState);
+  executeEnemyActions();
+}
+
+function executeEnemyActions(): void {
+  if (state.winner) {
+    return;
+  }
+
+  const playableCard = enemyState.hand.find((card) => canPlayCard(state, enemyState, card));
+  if (playableCard) {
+    const targets = pickDefaultTargets(state, enemyState, playableCard);
+    playCard(state, enemyState, playableCard, targets);
+  }
+
+  const attacker = enemyState.monsters[0];
+  if (attacker) {
+    const defender = playerState.monsters[0];
+    if (defender) {
+      monsterAttackMonster(state, attacker, defender, enemyState);
+    } else {
+      monsterAttackPlayer(state, attacker, playerState, enemyState);
+    }
+  }
+
+  finalizeVictory();
+  if (state.winner) {
+    return;
+  }
+
+  state.turn += 1;
+  startPlayerTurn();
+}
+
+function handleCardSelected(card: Card): void {
+  if (state.phase !== 'player' || state.winner) {
+    return;
+  }
+
+  const player = playerState;
+  if (!canPlayCard(state, player, card)) {
+    state.selectedCardId = card.instanceId;
+    state.pendingSelection = undefined;
+    addLog(state, `${card.name}の条件が満たされていません。`);
+    return;
+  }
+
+  state.selectedCardId = card.instanceId;
+  const targets = getValidTargets(state, player, card);
+  if (card.target === 'none' || targets.length === 0) {
+    playCard(state, player, card, []);
+    finalizeVictory();
+    resetSelection();
+    return;
+  }
+
+  state.pendingSelection = { card, targets, targetType: card.target };
+}
+
+function resolveCardWithTargets(targets: (Monster | PlayerState)[]): void {
+  const selection = state.pendingSelection;
+  if (!selection) {
+    return;
+  }
+  const { card } = selection;
+  playCard(state, playerState, card, targets);
+  finalizeVictory();
+  resetSelection();
+}
+
+function handleMonsterTarget(owner: 0 | 1, monster: Monster): void {
+  if (state.phase !== 'player' || state.winner || !state.pendingSelection) {
+    return;
+  }
+  if (!state.pendingSelection.targets.includes(monster)) {
+    return;
+  }
+  resolveCardWithTargets([monster]);
+}
+
+function handlePlayerTarget(owner: 0 | 1): void {
+  if (state.phase !== 'player' || state.winner || !state.pendingSelection) {
+    return;
+  }
+  const targetPlayer = state.players[owner];
+  if (!state.pendingSelection.targets.includes(targetPlayer)) {
+    return;
+  }
+  resolveCardWithTargets([targetPlayer]);
+}
+
+function handleBackground(): void {
+  if (state.phase !== 'player') {
+    return;
+  }
+  resetSelection();
+}
+
+function endPlayerTurn(): void {
+  if (state.phase !== 'player' || state.winner) {
+    return;
+  }
+  addLog(state, 'プレイヤーはターンを終了した。');
+  startEnemyTurn();
+}
+
+installInputHandlers(canvas, state, {
+  onCardSelected: handleCardSelected,
+  onMonsterTarget: handleMonsterTarget,
+  onPlayerTarget: handlePlayerTarget,
+  onBackground: handleBackground,
+  onEndTurn: endPlayerTurn,
+});
+
+addLog(state, 'ゲーム開始。');
+drawCard(state, playerState, 3);
+drawCard(state, enemyState, 3);
+startPlayerTurn();
+
+function loop(timestamp: number) {
+  state.lastUpdate = timestamp;
+  renderGame(renderContext, state);
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,305 @@
+import { ATTRIBUTE_ORDER } from './guts';
+import { canPlayCard } from './rules';
+import {
+  Card,
+  GameState,
+  Monster,
+  PlayerState,
+  Rect,
+  TargetableEntity,
+} from './types';
+
+const BACKGROUND_COLOR = '#0b0d12';
+const PANEL_COLOR = 'rgba(20, 28, 42, 0.82)';
+const PANEL_BORDER = 'rgba(90, 118, 168, 0.6)';
+const HIGHLIGHT_COLOR = '#f5c542';
+const CARD_WIDTH = 130;
+const CARD_HEIGHT = 180;
+const CARD_GAP = 14;
+const MONSTER_WIDTH = 150;
+const MONSTER_HEIGHT = 120;
+
+const ATTRIBUTE_LABEL: Record<string, string> = {
+  neutral: '無',
+  fire: '火',
+  water: '水',
+  earth: '土',
+  wind: '風',
+  light: '光',
+  dark: '闇',
+};
+
+function drawPanel(ctx: CanvasRenderingContext2D, rect: Rect, title?: string): void {
+  ctx.fillStyle = PANEL_COLOR;
+  ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+  ctx.strokeStyle = PANEL_BORDER;
+  ctx.lineWidth = 2;
+  ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
+  if (title) {
+    ctx.fillStyle = '#f0f6ff';
+    ctx.font = '16px "Segoe UI", sans-serif';
+    ctx.fillText(title, rect.x + 12, rect.y + 24);
+  }
+}
+
+function isTargetHighlighted(state: GameState, entity: TargetableEntity): boolean {
+  if (!state.pendingSelection) {
+    return false;
+  }
+  return state.pendingSelection.targets.includes(entity);
+}
+
+function drawStatusPanel(ctx: CanvasRenderingContext2D, rect: Rect, player: PlayerState, state: GameState): void {
+  drawPanel(ctx, rect);
+  const highlighted = isTargetHighlighted(state, player);
+  if (highlighted) {
+    ctx.strokeStyle = HIGHLIGHT_COLOR;
+    ctx.lineWidth = 3;
+    ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
+  }
+
+  ctx.fillStyle = '#f0f6ff';
+  ctx.font = '18px "Segoe UI", sans-serif';
+  ctx.fillText(player.name, rect.x + 12, rect.y + 26);
+
+  ctx.font = '14px "Segoe UI", sans-serif';
+  ctx.fillText(`HP: ${player.hp}`, rect.x + 12, rect.y + 52);
+  ctx.fillText(`デッキ: ${player.deck.length}`, rect.x + 12, rect.y + 74);
+  ctx.fillText(`手札: ${player.hand.length}`, rect.x + 12, rect.y + 96);
+  ctx.fillText(`捨札: ${player.discard.length}`, rect.x + 110, rect.y + 96);
+}
+
+function drawEnergyPanel(ctx: CanvasRenderingContext2D, rect: Rect, player: PlayerState): void {
+  drawPanel(ctx, rect, 'エネルギー');
+  ctx.fillStyle = '#f0f6ff';
+  ctx.font = '16px "Segoe UI", sans-serif';
+  ctx.fillText(`ガッツ: ${player.guts.guts}/${player.guts.maxGuts}`, rect.x + 12, rect.y + 48);
+
+  ctx.font = '13px "Segoe UI", sans-serif';
+  let line = 0;
+  for (const attribute of ATTRIBUTE_ORDER) {
+    const label = ATTRIBUTE_LABEL[attribute];
+    const amount = player.guts.attributes[attribute] ?? 0;
+    const text = `${label}: ${amount}`;
+    const offsetX = rect.x + 12 + (line % 2) * 110;
+    const offsetY = rect.y + 76 + Math.floor(line / 2) * 20;
+    ctx.fillText(text, offsetX, offsetY);
+    line += 1;
+  }
+}
+
+function drawMonster(ctx: CanvasRenderingContext2D, rect: Rect, monster: Monster, state: GameState): void {
+  drawPanel(ctx, rect, monster.name);
+  const highlighted = isTargetHighlighted(state, monster);
+  if (highlighted) {
+    ctx.strokeStyle = HIGHLIGHT_COLOR;
+    ctx.lineWidth = 3;
+    ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
+  }
+
+  ctx.fillStyle = '#dbe8ff';
+  ctx.font = '13px "Segoe UI", sans-serif';
+  ctx.fillText(`HP ${monster.hp}/${monster.maxHp}`, rect.x + 12, rect.y + 52);
+  ctx.fillText(`攻 ${monster.attack}`, rect.x + 12, rect.y + 74);
+  ctx.fillText(`守 ${monster.defense}`, rect.x + 12, rect.y + 96);
+  ctx.fillText(`属性 ${ATTRIBUTE_LABEL[monster.attribute]}`, rect.x + 12, rect.y + 118);
+  ctx.fillText(`種族 ${monster.tribe}`, rect.x + 80, rect.y + 96);
+}
+
+function drawCard(ctx: CanvasRenderingContext2D, rect: Rect, card: Card, state: GameState, player: PlayerState): void {
+  const selected = state.selectedCardId === card.instanceId;
+  const playable = state.phase === 'player' && canPlayCard(state, player, card);
+
+  ctx.fillStyle = playable ? 'rgba(53, 70, 104, 0.9)' : 'rgba(34, 42, 56, 0.8)';
+  ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+  ctx.strokeStyle = selected ? HIGHLIGHT_COLOR : PANEL_BORDER;
+  ctx.lineWidth = selected ? 3 : 2;
+  ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
+
+  ctx.fillStyle = '#f0f6ff';
+  ctx.font = '16px "Segoe UI", sans-serif';
+  ctx.fillText(card.name, rect.x + 10, rect.y + 28);
+
+  ctx.font = '12px "Segoe UI", sans-serif';
+  const descriptionLines = wrapText(ctx, card.description, rect.width - 20);
+  descriptionLines.forEach((line, index) => {
+    ctx.fillText(line, rect.x + 10, rect.y + 54 + index * 16);
+  });
+
+  ctx.font = '11px "Segoe UI", sans-serif';
+  let costText = '';
+  if (card.requirement.cost?.guts) {
+    costText += `G${card.requirement.cost.guts} `;
+  }
+  if (card.requirement.cost?.attributes) {
+    const entries = Object.entries(card.requirement.cost.attributes)
+      .filter(([, value]) => (value ?? 0) > 0)
+      .map(([key, value]) => `${ATTRIBUTE_LABEL[key]}${value}`);
+    costText += entries.join(' ');
+  }
+  ctx.fillText(costText.trim(), rect.x + 10, rect.y + rect.height - 20);
+}
+
+function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+  const lines: string[] = [];
+  let current = '';
+  for (const char of Array.from(text)) {
+    const testLine = current + char;
+    if (ctx.measureText(testLine).width > maxWidth && current) {
+      lines.push(current);
+      current = char;
+    } else {
+      current = testLine;
+    }
+    if (lines.length >= 5) {
+      break;
+    }
+  }
+  if (current && lines.length < 5) {
+    lines.push(current);
+  }
+  return lines;
+}
+
+function drawLog(ctx: CanvasRenderingContext2D, rect: Rect, state: GameState): void {
+  drawPanel(ctx, rect, 'ログ');
+  ctx.fillStyle = '#d0ddf5';
+  ctx.font = '12px "Segoe UI", sans-serif';
+  const lines = state.log.slice(-12);
+  lines.forEach((line, index) => {
+    ctx.fillText(line, rect.x + 12, rect.y + 30 + index * 16);
+  });
+}
+
+function drawEndTurnButton(ctx: CanvasRenderingContext2D, rect: Rect, state: GameState): void {
+  const enabled = state.phase === 'player' && !state.winner;
+  ctx.fillStyle = enabled ? 'rgba(64, 128, 192, 0.85)' : 'rgba(54, 70, 90, 0.7)';
+  ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+  ctx.strokeStyle = PANEL_BORDER;
+  ctx.lineWidth = 2;
+  ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
+
+  ctx.fillStyle = '#f0f6ff';
+  ctx.font = '18px "Segoe UI", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('ターン終了', rect.x + rect.width / 2, rect.y + rect.height / 2 + 6);
+  ctx.textAlign = 'left';
+}
+
+function drawVictoryOverlay(ctx: CanvasRenderingContext2D, state: GameState): void {
+  if (!state.winner) {
+    return;
+  }
+  const { width, height } = ctx.canvas;
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.65)';
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = '#f8fbff';
+  ctx.font = '48px "Segoe UI", sans-serif';
+  ctx.textAlign = 'center';
+  const message = state.winner === 'player' ? '勝利！' : '敗北...';
+  ctx.fillText(message, width / 2, height / 2);
+  ctx.font = '20px "Segoe UI", sans-serif';
+  ctx.fillText('リロードで再戦できます。', width / 2, height / 2 + 48);
+  ctx.textAlign = 'left';
+}
+
+export function renderGame(ctx: CanvasRenderingContext2D, state: GameState): void {
+  const { canvas } = ctx;
+  const width = canvas.width;
+  const height = canvas.height;
+
+  ctx.fillStyle = BACKGROUND_COLOR;
+  ctx.fillRect(0, 0, width, height);
+
+  const enemyStatusRect: Rect = { x: 24, y: 24, width: 260, height: 110 };
+  const playerStatusRect: Rect = { x: 24, y: 146, width: 260, height: 110 };
+  const energyRect: Rect = { x: width - 280, y: 24, width: 256, height: 160 };
+  const logRect: Rect = { x: width - 280, y: 200, width: 256, height: height - 240 };
+  const endTurnRect: Rect = { x: width - 220, y: height - 80, width: 180, height: 54 };
+
+  state.layout.enemyStatusRect = enemyStatusRect;
+  state.layout.playerStatusRect = playerStatusRect;
+  state.layout.energyRect = energyRect;
+  state.layout.logRect = logRect;
+  state.layout.endTurnRect = endTurnRect;
+
+  drawStatusPanel(ctx, enemyStatusRect, state.players[1], state);
+  drawStatusPanel(ctx, playerStatusRect, state.players[0], state);
+  drawEnergyPanel(ctx, energyRect, state.players[0]);
+  drawLog(ctx, logRect, state);
+  drawEndTurnButton(ctx, endTurnRect, state);
+
+  drawMonsters(ctx, state);
+  drawHandArea(ctx, state);
+  drawVictoryOverlay(ctx, state);
+}
+
+function drawMonsters(ctx: CanvasRenderingContext2D, state: GameState): void {
+  const { width } = ctx.canvas;
+  const enemyArea: Rect = { x: width / 2 - 250, y: 220, width: 500, height: MONSTER_HEIGHT };
+  const playerArea: Rect = { x: width / 2 - 250, y: 420, width: 500, height: MONSTER_HEIGHT };
+
+  state.layout.enemyMonsterRects = {};
+  state.layout.playerMonsterRects = {};
+
+  drawMonsterRow(ctx, enemyArea, state.players[1], state, state.layout.enemyMonsterRects);
+  drawMonsterRow(ctx, playerArea, state.players[0], state, state.layout.playerMonsterRects);
+}
+
+function drawMonsterRow(
+  ctx: CanvasRenderingContext2D,
+  area: Rect,
+  player: PlayerState,
+  state: GameState,
+  collection: Record<string, Rect>,
+): void {
+  const monsters = player.monsters;
+  if (monsters.length === 0) {
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)';
+    ctx.strokeRect(area.x, area.y, area.width, area.height);
+    ctx.font = '14px "Segoe UI", sans-serif';
+    ctx.fillStyle = '#c5d4f3';
+    ctx.fillText('モンスターなし', area.x + area.width / 2 - 48, area.y + area.height / 2 + 6);
+    return;
+  }
+
+  const totalWidth = monsters.length * (MONSTER_WIDTH + CARD_GAP) - CARD_GAP;
+  const startX = Math.max(area.x, area.x + (area.width - totalWidth) / 2);
+
+  monsters.forEach((monster, index) => {
+    const rect: Rect = {
+      x: startX + index * (MONSTER_WIDTH + CARD_GAP),
+      y: area.y,
+      width: MONSTER_WIDTH,
+      height: MONSTER_HEIGHT,
+    };
+    collection[monster.instanceId] = rect;
+    drawMonster(ctx, rect, monster, state);
+  });
+}
+
+function drawHandArea(ctx: CanvasRenderingContext2D, state: GameState): void {
+  const { width, height } = ctx.canvas;
+  const player = state.players[0];
+  const hand = player.hand;
+  state.layout.handRects = {};
+
+  const areaY = height - CARD_HEIGHT - 40;
+  const totalWidth = hand.length * (CARD_WIDTH + CARD_GAP) - CARD_GAP;
+  const startX = totalWidth > 0 ? Math.max(32, (width - totalWidth) / 2) : width / 2;
+
+  hand.forEach((card, index) => {
+    const rect: Rect = {
+      x: startX + index * (CARD_WIDTH + CARD_GAP),
+      y: areaY,
+      width: CARD_WIDTH,
+      height: CARD_HEIGHT,
+    };
+    state.layout.handRects[card.instanceId] = rect;
+    drawCard(ctx, rect, card, state, player);
+  });
+
+  ctx.fillStyle = '#8fa9d6';
+  ctx.font = '14px "Segoe UI", sans-serif';
+  ctx.fillText('スペースキーまたはボタンでターン終了', width / 2 - 140, height - 12);
+}

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,0 +1,249 @@
+import { Card, GameState, Monster, PlayerIndex, PlayerState, TargetableEntity } from './types';
+import { canPay, pay } from './guts';
+
+const LOG_LIMIT = 18;
+
+export function addLog(state: GameState, message: string): void {
+  state.log.push(message);
+  if (state.log.length > LOG_LIMIT) {
+    state.log.splice(0, state.log.length - LOG_LIMIT);
+  }
+}
+
+export function shuffle<T>(items: T[], rng: () => number): T[] {
+  for (let i = items.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
+  return items;
+}
+
+export function getPlayerIndex(player: PlayerState): PlayerIndex {
+  return player.index;
+}
+
+export function getOpponent(state: GameState, player: PlayerState): PlayerState {
+  return player.id === 'player' ? state.players[1] : state.players[0];
+}
+
+function hasAttributeRequirement(card: Card, player: PlayerState): boolean {
+  if (!card.requirement.requiresAttribute) {
+    return true;
+  }
+  return player.monsters.some((monster) => monster.attribute === card.requirement.requiresAttribute);
+}
+
+function hasTribeRequirement(card: Card, player: PlayerState): boolean {
+  if (!card.requirement.requiresTribe) {
+    return true;
+  }
+  return player.monsters.some((monster) => monster.tribe === card.requirement.requiresTribe);
+}
+
+function hasUniqueRequirement(card: Card, player: PlayerState): boolean {
+  if (!card.requirement.requiresMonsterId) {
+    return true;
+  }
+  return player.monsters.some((monster) => monster.id === card.requirement.requiresMonsterId);
+}
+
+export function meetsCardRequirements(card: Card, player: PlayerState): boolean {
+  return hasAttributeRequirement(card, player) && hasTribeRequirement(card, player) && hasUniqueRequirement(card, player);
+}
+
+export function getValidTargets(state: GameState, player: PlayerState, card: Card): TargetableEntity[] {
+  const opponent = getOpponent(state, player);
+  switch (card.target) {
+    case 'ally-monster':
+      return [...player.monsters];
+    case 'enemy-monster':
+      return [...opponent.monsters];
+    case 'any-monster':
+      return [...player.monsters, ...opponent.monsters];
+    case 'ally-player':
+      return [player];
+    case 'enemy-player':
+      return [opponent];
+    case 'ally-any':
+      return [player, ...player.monsters];
+    case 'enemy-any':
+      return [opponent, ...opponent.monsters];
+    case 'none':
+    default:
+      return [];
+  }
+}
+
+export function canPlayCard(state: GameState, player: PlayerState, card: Card): boolean {
+  if (!meetsCardRequirements(card, player)) {
+    return false;
+  }
+
+  if (!canPay(player.guts, card.requirement.cost)) {
+    return false;
+  }
+
+  if (card.target !== 'none' && getValidTargets(state, player, card).length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+function removeCardFromHand(player: PlayerState, card: Card): Card | null {
+  const index = player.hand.findIndex((candidate) => candidate.instanceId === card.instanceId);
+  if (index === -1) {
+    return null;
+  }
+  const [removed] = player.hand.splice(index, 1);
+  return removed;
+}
+
+export function playCard(state: GameState, player: PlayerState, card: Card, targets: TargetableEntity[]): void {
+  const opponent = getOpponent(state, player);
+  const cardInHand = removeCardFromHand(player, card);
+  if (!cardInHand) {
+    return;
+  }
+
+  if (!pay(player.guts, card.requirement.cost)) {
+    player.hand.push(cardInHand);
+    return;
+  }
+
+  addLog(state, `${player.name}は「${card.name}」を使用した。`);
+
+  card.effect({
+    state,
+    sourcePlayer: player,
+    targetPlayer: opponent,
+    targets,
+    log: (message: string) => addLog(state, message),
+  });
+
+  player.discard.push(cardInHand);
+}
+
+export function drawCard(state: GameState, player: PlayerState, amount = 1): void {
+  for (let i = 0; i < amount; i += 1) {
+    const card = player.deck.shift();
+    if (!card) {
+      addLog(state, `${player.name}はドローできるカードがない。`);
+      return;
+    }
+    player.hand.push(card);
+    addLog(state, `${player.name}は「${card.name}」をドローした。`);
+  }
+}
+
+export function findMonsterOwner(state: GameState, instanceId: string): [PlayerIndex, Monster | undefined] {
+  for (const player of state.players) {
+    const monster = player.monsters.find((candidate) => candidate.instanceId === instanceId);
+    if (monster) {
+      return [player.index, monster];
+    }
+  }
+  return [0, undefined];
+}
+
+export function applyMonsterDamage(state: GameState, target: Monster, amount: number, source?: string): void {
+  const [ownerIndex, monster] = findMonsterOwner(state, target.instanceId);
+  if (!monster) {
+    return;
+  }
+
+  const actualAmount = Math.max(0, Math.floor(amount));
+  if (actualAmount <= 0) {
+    return;
+  }
+
+  monster.hp = Math.max(0, monster.hp - actualAmount);
+  addLog(state, `${source ?? '効果'}が${monster.name}に${actualAmount}ダメージ。`);
+
+  if (monster.hp <= 0) {
+    addLog(state, `${monster.name}は倒れた。`);
+    state.players[ownerIndex].monsters = state.players[ownerIndex].monsters.filter((candidate) => candidate.instanceId !== monster.instanceId);
+  }
+}
+
+export function healMonster(state: GameState, target: Monster, amount: number, source?: string): void {
+  const [, monster] = findMonsterOwner(state, target.instanceId);
+  if (!monster) {
+    return;
+  }
+
+  const actualAmount = Math.max(0, Math.floor(amount));
+  if (actualAmount <= 0) {
+    return;
+  }
+
+  const previous = monster.hp;
+  monster.hp = Math.min(monster.maxHp, monster.hp + actualAmount);
+  const healed = monster.hp - previous;
+  if (healed > 0) {
+    addLog(state, `${source ?? '効果'}が${monster.name}を${healed}回復した。`);
+  }
+}
+
+export function damagePlayer(state: GameState, player: PlayerState, amount: number, source?: string): void {
+  const actualAmount = Math.max(0, Math.floor(amount));
+  if (actualAmount <= 0) {
+    return;
+  }
+
+  player.hp = Math.max(0, player.hp - actualAmount);
+  addLog(state, `${source ?? '攻撃'}が${player.name}に${actualAmount}ダメージ。`);
+}
+
+export function monsterAttackMonster(
+  state: GameState,
+  attacker: Monster,
+  defender: Monster,
+  attackerOwner: PlayerState,
+): void {
+  const attackPower = Math.max(1, attacker.attack - defender.defense);
+  addLog(state, `${attackerOwner.name}の${attacker.name}が${defender.name}を攻撃(${attackPower}ダメージ)。`);
+  applyMonsterDamage(state, defender, attackPower, attacker.name);
+}
+
+export function monsterAttackPlayer(
+  state: GameState,
+  attacker: Monster,
+  defender: PlayerState,
+  attackerOwner: PlayerState,
+): void {
+  const damage = Math.max(1, attacker.attack);
+  addLog(state, `${attackerOwner.name}の${attacker.name}が直接攻撃(${damage}ダメージ)。`);
+  damagePlayer(state, defender, damage, attacker.name);
+}
+
+export function pickDefaultTargets(state: GameState, player: PlayerState, card: Card): TargetableEntity[] {
+  const targets = getValidTargets(state, player, card);
+  if (targets.length <= 1) {
+    return targets.slice();
+  }
+
+  if (card.target === 'enemy-monster' || card.target === 'any-monster') {
+    const monsters = targets.filter((target): target is Monster => 'hp' in target);
+    monsters.sort((a, b) => a.hp - b.hp);
+    return monsters.length > 0 ? [monsters[0]] : [];
+  }
+
+  return [targets[0]];
+}
+
+export function checkVictory(state: GameState): 'player' | 'enemy' | null {
+  const player = state.players[0];
+  const enemy = state.players[1];
+
+  if (player.hp <= 0 && enemy.hp <= 0) {
+    return 'player';
+  }
+  if (enemy.hp <= 0) {
+    return 'player';
+  }
+  if (player.hp <= 0) {
+    return 'enemy';
+  }
+  return null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,126 @@
+export type Attribute =
+  | 'neutral'
+  | 'fire'
+  | 'water'
+  | 'earth'
+  | 'wind'
+  | 'light'
+  | 'dark';
+
+export type Tribe = 'human' | 'beast' | 'dragon' | 'spirit' | 'undead';
+
+export interface Monster {
+  id: string;
+  instanceId: string;
+  name: string;
+  attribute: Attribute;
+  tribe: Tribe;
+  maxHp: number;
+  hp: number;
+  attack: number;
+  defense: number;
+}
+
+export type PlayerIndex = 0 | 1;
+
+export type EnergyMap = Record<Attribute, number>;
+
+export interface EnergyCost {
+  guts?: number;
+  attributes?: Partial<Record<Attribute, number>>;
+}
+
+export interface CardRequirement {
+  cost?: EnergyCost;
+  requiresAttribute?: Attribute;
+  requiresTribe?: Tribe;
+  requiresMonsterId?: string;
+}
+
+export type TargetType =
+  | 'none'
+  | 'ally-monster'
+  | 'enemy-monster'
+  | 'any-monster'
+  | 'ally-player'
+  | 'enemy-player'
+  | 'ally-any'
+  | 'enemy-any';
+
+export interface PlayerState {
+  id: 'player' | 'enemy';
+  index: PlayerIndex;
+  name: string;
+  hp: number;
+  deck: Card[];
+  hand: Card[];
+  discard: Card[];
+  monsters: Monster[];
+  guts: GutsContext;
+}
+
+export interface GameState {
+  players: [PlayerState, PlayerState];
+  activePlayer: PlayerIndex;
+  turn: number;
+  phase: 'player' | 'enemy' | 'victory';
+  log: string[];
+  rng: () => number;
+  layout: LayoutInfo;
+  selectedCardId?: string;
+  pendingSelection?: PendingSelection;
+  winner?: 'player' | 'enemy';
+  lastUpdate: number;
+}
+
+export interface CardEffectContext {
+  state: GameState;
+  sourcePlayer: PlayerState;
+  targetPlayer: PlayerState;
+  targets: (Monster | PlayerState)[];
+  log: (message: string) => void;
+}
+
+export interface Card {
+  id: string;
+  instanceId: string;
+  name: string;
+  description: string;
+  attribute: Attribute;
+  requirement: CardRequirement;
+  target: TargetType;
+  effect: (context: CardEffectContext) => void;
+}
+
+export interface GutsContext {
+  guts: number;
+  maxGuts: number;
+  perTurnGain: number;
+  attributes: EnergyMap;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface LayoutInfo {
+  handRects: Record<string, Rect>;
+  playerMonsterRects: Record<string, Rect>;
+  enemyMonsterRects: Record<string, Rect>;
+  playerStatusRect: Rect;
+  enemyStatusRect: Rect;
+  energyRect: Rect;
+  endTurnRect: Rect;
+  logRect: Rect;
+}
+
+export interface PendingSelection {
+  card: Card;
+  targets: (Monster | PlayerState)[];
+  targetType: TargetType;
+}
+
+export type TargetableEntity = Monster | PlayerState;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript domain types and Guts system helpers for card cost handling
- implement core game rules, sample cards, and turn orchestration with simple enemy AI
- render the battlefield, hand, and log on canvas with click/keyboard input and build configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccf72c5ebc832e89a3dc915eedb6f0